### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This MCP server allows LLMs (such as Cursor or Claude) to interact with your Clo
 - Generate monthly or custom date range breakdowns of hours by user and project using the Clockify summary report API
 - Integrate with LLMs to automate, summarize, or analyze your time-tracking data
 
+<a href="https://glama.ai/mcp/servers/@inakianduaga/clockify-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@inakianduaga/clockify-mcp/badge" alt="Clockify MCP server" />
+</a>
+
 ## Features
 - **listProjects:** List all projects for the authenticated user
 - **getTimeEntries:** List time entries for the authenticated user (with optional date filters)


### PR DESCRIPTION
This PR adds a badge for the [Clockify MCP](https://glama.ai/mcp/servers/@inakianduaga/clockify-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@inakianduaga/clockify-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@inakianduaga/clockify-mcp/badge" alt="Clockify MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.